### PR TITLE
Fix Wasm and WebAssembly capitalization in `swal.html`

### DIFF
--- a/swal.html
+++ b/swal.html
@@ -75,7 +75,7 @@
     </head>
     <body>
         <header class="h-flex centered">
-            <h1>Swift, WASM, and Algorithms</h1>
+            <h1>Swift, Wasm, and Algorithms</h1>
             <div class="h-flex">
                 <a href="https://github.com/johngarrett/swal-wasm" style="margin-right: 10px;">
                     <img src="https://garrepi.dev/images/github-white.png" alt="github"/>
@@ -90,7 +90,7 @@
             <p>
             I hate javascript as much as the next guy; I mostly navigate with it turned off.
             <br>
-            However, this site is powered by web assembly. For the interoperation to work, Javascript is required.
+            However, this site is powered by WebAssembly. For the interoperation to work, Javascript is required.
             </p>
             <small>
             Thanks for understanding


### PR DESCRIPTION
These are now written in accordance with the WebAssembly spec.